### PR TITLE
Video Embedding into Posts + Some small fixes / enhancements 

### DIFF
--- a/controllers/posts.go
+++ b/controllers/posts.go
@@ -101,6 +101,9 @@ func CreatePost(c *gin.Context) {
 	if err := c.ShouldBind(&input); err != nil {
 		c.HTML(http.StatusBadRequest, "create.tmpl", gin.H{
 			"error": "Invalid request",
+			"title": input.Title,
+			"content": input.Content,
+			"video_link": input.VideoLink,
 		})
 		c.Error(err)
 		return
@@ -110,6 +113,9 @@ func CreatePost(c *gin.Context) {
 	if !ok {
 		c.HTML(http.StatusInternalServerError, "create.tmpl", gin.H{
 			"error": "Internal Server Error",
+			"title": input.Title,
+			"content": input.Content,
+			"video_link": input.VideoLink,
 		})
 		return
 	}
@@ -118,6 +124,9 @@ func CreatePost(c *gin.Context) {
 	if err != nil {
 		c.HTML(http.StatusBadRequest, "create.tmpl", gin.H{
 			"error": "Invalid request",
+			"title": input.Title,
+			"content": input.Content,
+			"video_link": input.VideoLink,
 		})
 		c.Error(err)
 		return
@@ -128,6 +137,9 @@ func CreatePost(c *gin.Context) {
 	if err != nil {
 		c.HTML(http.StatusInternalServerError, "create.tmpl", gin.H{
 			"error": "Internal Server Error",
+			"title": input.Title,
+			"content": input.Content,
+			"video_link": input.VideoLink,
 		})
 		c.Error(err)
 		return
@@ -138,7 +150,9 @@ func CreatePost(c *gin.Context) {
 	if err != nil {
 		c.HTML(http.StatusBadRequest, "create.tmpl", gin.H{
 			"error": err.Error(),
-
+			"title": input.Title,
+			"content": input.Content,
+			"video_link": input.VideoLink,
 		})
 		c.Error(err)
 		return
@@ -159,6 +173,9 @@ func CreatePost(c *gin.Context) {
 	if err != nil {
 		c.HTML(http.StatusInternalServerError, "create.tmpl", gin.H{
 			"error": "Internal Server Error",
+			"title": input.Title,
+			"content": input.Content,
+			"video_link": input.VideoLink,
 		})
 		c.Error(err)
 		return

--- a/models/post.go
+++ b/models/post.go
@@ -15,4 +15,5 @@ type Post struct {
 	Content   string                      `json:"content"`
 	Images    datatypes.JSONSlice[string] `json:"images"`
 	Comments  []Comment                   `json:"comments" gorm:"foreignKey:PostID;references:ID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
+	EmbedVideo string                     `json:"embed_video"`
 }

--- a/templates/create.tmpl
+++ b/templates/create.tmpl
@@ -70,6 +70,11 @@
                     <input type="file" id="images" name="images" accept="image/*" multiple>
                 </div>
                 <br></br>
+                <div class="row">
+                    <label for="video_link">Embed Video Link:</label>
+                    <input type="text" id="video_link" name="video_link" placeholder="Embed Video Link">
+                </div>
+                <br></br>
 				<div class="row">
 					<input type="submit" value="Post">
 				</div>

--- a/templates/create.tmpl
+++ b/templates/create.tmpl
@@ -60,10 +60,10 @@
 
 			<form action="/create" method="POST", enctype="multipart/form-data">
 				<div class="row">
-					<input type="text" id="title" name="title" placeholder="Title" required>
+					<input type="text" id="title" name="title" placeholder="Title" value="{{.title}}" required>
 				</div>
 				<div class="row">
-					<textarea id="content" name="content" placeholder="Was los?" style="height:200px"></textarea>
+					<textarea id="content" name="content" placeholder="Was los?" style="height:200px">{{.content}}</textarea>
 				</div>
 				<div class="row">
                     <label for="images">Images:</label>
@@ -72,7 +72,7 @@
                 <br></br>
                 <div class="row">
                     <label for="video_link">Embed Video Link:</label>
-                    <input type="text" id="video_link" name="video_link" placeholder="Embed Video Link">
+                    <input type="text" id="video_link" name="video_link" placeholder="Embed Video Link" value="{{.video_link}}">
                 </div>
                 <br></br>
 				<div class="row">

--- a/templates/create.tmpl
+++ b/templates/create.tmpl
@@ -60,7 +60,7 @@
 
 			<form action="/create" method="POST", enctype="multipart/form-data">
 				<div class="row">
-					<input type="text" id="title" name="title" placeholder="Title">
+					<input type="text" id="title" name="title" placeholder="Title" required>
 				</div>
 				<div class="row">
 					<textarea id="content" name="content" placeholder="Was los?" style="height:200px"></textarea>

--- a/templates/post.tmpl
+++ b/templates/post.tmpl
@@ -63,6 +63,18 @@
                 max-height: 65vh;
             }
 
+            .video-box {
+				width: 80%;
+				background: white;
+				padding: 20px;
+				margin: 0 auto 20px;
+				border: 2px solid #ddd;
+				border-radius: 5px;
+                display: flex;
+                justify-content: center; /* Center horizontally */
+                align-items: center;   
+			}
+
 
 			textarea {
 				width: 100%;
@@ -128,6 +140,13 @@
                 </div>
             {{ end }}
         </div>
+
+        {{ if .EmbedVideo }}
+            <div class="video-box">
+                <iframe width="560" height="315" src="{{ .EmbedVideo }}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            </div>
+        {{ end }}
+
         <h4 style="text-align:center">Comments</h4>
         {{ range .Comments }}
             <div class="comment-box">


### PR DESCRIPTION
## What does this PR change?
- Allows users to optionally embed a youtube video to their post
- Fixes a infinite redirect bug if there are no posts present yet
- Restores post creation content (except images) if a post submission fails

## Details
#### UI changes:
Create Posts page:
<img width="1087" height="773" alt="image" src="https://github.com/user-attachments/assets/8f2a6cd4-391d-40ae-a653-11159d0c4d69" />
Title is now required by the form:
<img width="1088" height="754" alt="image" src="https://github.com/user-attachments/assets/a1277f3e-08b1-47cf-9cbe-9f09d6ff6d6e" />
Consice error messages for link submission:
<img width="1089" height="739" alt="image" src="https://github.com/user-attachments/assets/bae19d56-24b1-420b-b050-758b3c834844" />
Post with Video:
<img width="1085" height="1185" alt="image" src="https://github.com/user-attachments/assets/3d196c25-1b40-450c-ae01-a0847ebb6108" />
#### Others
- Database model change