### PR TITLE
Improve error messages on post creation

### DIFF
--- a/templates/create.tmpl
+++ b/templates/create.tmpl
@@ -35,6 +35,7 @@
 
             .error {
                 color: red;
+                white-space: break-spaces;
                 text-align: center;
             }
             .back {


### PR DESCRIPTION
To create a post the title is required. Furthermore one of text, image(s) or youtube link must be provided. This is now better communicated with the user. A note to reselect images upon error was also added.